### PR TITLE
Fix dataset router definition

### DIFF
--- a/app/api/datasets.py
+++ b/app/api/datasets.py
@@ -15,7 +15,6 @@ from app.services.hf_datasets import (
 router = APIRouter(prefix="/datasets", tags=["datasets"])
 
 @router.get("")
-@router.get("")
 async def list_datasets_endpoint(
     limit: int | None = Query(None, ge=1),
     search: str | None = None,


### PR DESCRIPTION
## Summary
- deduplicate the empty `@router.get` decorator in `app/api/datasets.py`

## Testing
- `ruff check app`