### PR TITLE
Improve CLI for test script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 SUPABASE_URL=https://example.supabase.co
 SUPABASE_ANON_KEY=example_key
+
+# Optional credentials for test.sh
+EMAIL=test@example.com
+PASSWORD=secret


### PR DESCRIPTION
## Summary
- add example credentials to `.env.example`
- update `test.sh` to accept email/password arguments
- show clearer messages when credentials are missing
- keep follow tests gated on access token

## Testing
- `bash test.sh -h`
- `bash test.sh -l 1` *(fails: No datasets returned – is the API running?)*